### PR TITLE
add Element.prototype.toggleAttribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,12 @@ import 'mdn-polyfills/NodeList.prototype.forEach'; // 173 bytes
 import 'mdn-polyfills/Element.prototype.closest'; // 256 bytes
 ```
 
+### [Element.prototype.toggleAttribute](https://developer.mozilla.org/en-US/docs/Web/API/Element/toggleAttribute#Polyfill)
+
+```js
+import 'mdn-polyfills/Element.prototype.toggleAttribute'; // 256 bytes
+```
+
 ### [Element.prototype.matches](https://developer.mozilla.org/en-US/docs/Web/API/Element/matches#Polyfill)
 
 ```js

--- a/src/Element.prototype.toggleAttribute/index.js
+++ b/src/Element.prototype.toggleAttribute/index.js
@@ -1,0 +1,5 @@
+import toggle from './closest';
+
+if (window.Element && !Element.prototype.toggleAttribute) {
+    Element.prototype.toggleAttribute = toggle;
+}

--- a/src/Element.prototype.toggleAttribute/toggleattribute.js
+++ b/src/Element.prototype.toggleAttribute/toggleattribute.js
@@ -1,0 +1,17 @@
+export default function(name, force) {
+    var forcePassed = arguments.length === 2;
+    var forceOn = !!force;
+    var forceOff = forcePassed && !force;
+
+    if (this.getAttribute(name) !== null) {
+        if (forceOn) return true;
+
+        this.removeAttribute(name);
+        return false;
+    } else {
+        if (forceOff) return false;
+
+        this.setAttribute(name, "");
+        return true;
+    }
+};


### PR DESCRIPTION
This adds the new `Element.prototype.toggleAttribute` as recently added to the spec.

Docs here: https://developer.mozilla.org/en-US/docs/Web/API/Element/toggleAttribute