### PR TITLE
Update Element.prototype.closest

### DIFF
--- a/src/Element.prototype.closest/closest.js
+++ b/src/Element.prototype.closest/closest.js
@@ -1,10 +1,9 @@
 export default function(s) {
-    var matches = (this.document || this.ownerDocument).querySelectorAll(s),
-        i,
-        el = this;
+    var el = this;
+    if (!document.documentElement.contains(el)) return null;
     do {
-        i = matches.length;
-        while (--i >= 0 && matches.item(i) !== el) {};
-    } while ((i < 0) && (el = el.parentElement));
-    return el;
+        if (el.matches(s)) return el;
+        el = el.parentElement || el.parentNode;
+    } while (el !== null && el.nodeType === 1);
+    return null;
 };

--- a/src/Element.prototype.closest/index.js
+++ b/src/Element.prototype.closest/index.js
@@ -1,4 +1,5 @@
 import closest from './closest';
+import '../Element.prototype.matches';
 
 if (window.Element && !Element.prototype.closest) {
     Element.prototype.closest = closest;


### PR DESCRIPTION
This patch updates the Element.prototype.closest polyfill to the latest found at https://developer.mozilla.org/en-US/docs/Web/API/Element/closest#Polyfill

This polyfill now automatically pulls in the Element.prototype.matches polyfill as a dependency.

Closes #40