### PR TITLE
Add Number.isInteger Polyfill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .idea
 *.log
 dist
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ require('mdn-polyfills/String.prototype.padStart');
 |[Element.prototype.classList](https://developer.mozilla.org/en-US/docs/Web/API/Element/classList#Polyfill)|4433|
 |[MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/MouseEvent#Polyfill)|281|
 |[CustomEvent](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#Polyfill)|279|
+|[Number.isInteger](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger#Polyfill)|154|
 |[Number.isNaN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN#Polyfill)|53|
 |[HTMLCanvasElement.prototype.toBlob](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob#Polyfill)|276|
 

--- a/src/Number.isInteger/index.js
+++ b/src/Number.isInteger/index.js
@@ -1,0 +1,5 @@
+Number.isInteger = Number.isInteger || function(value) {
+  return typeof value === 'number' &&
+    isFinite(value) &&
+    Math.floor(value) === value;
+};


### PR DESCRIPTION
This adds the [Number.isInteger](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger) polyfill. Useful for anyone needing support in IE 11.