### PR TITLE
Add window argument to DOMTokenList polyfill

### DIFF
--- a/src/Element.prototype.classList/classList.js
+++ b/src/Element.prototype.classList/classList.js
@@ -140,7 +140,7 @@ export default function polyfillClassList(window) {
                 '[class]{x-uCLp/**/:expression(!this.hasOwnProperty("classList")&&window[" uCL"](this))}' //IE7-8
             );
         }
-    })();
+    })(window);
 
     // 3. Patch in unsupported methods in DOMTokenList
     (function (DOMTokenListProto, testClass) {


### PR DESCRIPTION
In the "DOMTokenList livelyness polyfill" `undefined` was passed in as the `window` argument.

CC @missmatsuko