### PR TITLE
Parameter dictionnary is taking parameters

### DIFF
--- a/src/MouseEvent/MouseEvent.js
+++ b/src/MouseEvent/MouseEvent.js
@@ -1,19 +1,36 @@
-export default function () {
-    try {
-        new MouseEvent('test');
-        return false; // No need to polyfill
-    } catch (e) {
-        // Need to polyfill - fall through
-    }
+(function (window) {
+  try {
+    new MouseEvent('test');
+    return false; // No need to polyfill
+  } catch (e) {
+		// Need to polyfill - fall through
+  }
 
     // Polyfills DOM4 MouseEvent
-    var MouseEvent = function (eventType, params) {
-        params = params || { bubbles: false, cancelable: false };
-        var mouseEvent = document.createEvent('MouseEvent');
-        mouseEvent.initMouseEvent(eventType, params.bubbles, params.cancelable, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
-        return mouseEvent;
-    };
+	var MouseEventPolyfill = function (eventType, params) {
+		params = params || { bubbles: false, cancelable: false };
+		var mouseEvent = document.createEvent('MouseEvent');
+		mouseEvent.initMouseEvent(eventType, 
+			params.bubbles,
+			params.cancelable,
+			window,
+			0,
+			params.screenX || 0,
+			params.screenY || 0,
+			params.clientX || 0,
+			params.clientY || 0,
+			params.ctrlKey || false,
+			params.altKey || false,
+			params.shiftKey || false,
+			params.metaKey || false,
+			params.button || 0,
+			params.relatedTarget || null
+		);
 
-    MouseEvent.prototype = Event.prototype;
-    window.MouseEvent = MouseEvent;
-}
+		return mouseEvent;
+	}
+
+	MouseEventPolyfill.prototype = Event.prototype;
+
+	window.MouseEvent = MouseEventPolyfill;
+})(window);


### PR DESCRIPTION
Update of the MouseEvent polyfill to fix #60 

So now when you do this below, parameters are taken and not replaced with default values  :
```
const evt: MouseEvent = new MouseEvent("MouseEvents", {
          clientX: x,
          clientY: y,
          screenX: x,
          screenY: y
        });
```