### PR TITLE
Add Object.keys polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Polyfills are also available over a CDN, for example
 |[Object.assign](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#Polyfill)|274|
 |[Object.create](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create#Polyfill)|299|
 |[Object.entries](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries)|151|
+|[Object.keys](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys)|723|
 |[Object.values](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/values)|142|
 |[Array.from](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/from?v=control#Polyfill)|788|
 |[Array.of](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/of#Polyfill)|79|

--- a/rollup.build.js
+++ b/rollup.build.js
@@ -25,6 +25,7 @@ function output(file) {
 rollup(input('./src/Object.assign/index.js')).then(output('./Object.assign.js'));
 rollup(input('./src/Object.create/index.js')).then(output('./Object.create.js'));
 rollup(input('./src/Object.entries/index.js')).then(output('./Object.entries.js'));
+rollup(input('./src/Object.keys/index.js')).then(output('./Object.keys.js'));
 rollup(input('./src/Object.values/index.js')).then(output('./Object.values.js'));
 rollup(input('./src/Array.prototype.find/index.js')).then(output('./Array.prototype.find.js'));
 rollup(input('./src/Array.from/index.js')).then(output('./Array.from.js'));

--- a/src/Object.keys/index.js
+++ b/src/Object.keys/index.js
@@ -1,0 +1,41 @@
+// From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys
+if (!Object.keys) {
+    Object.keys = (function() {
+        'use strict';
+        var hasOwnProperty = Object.prototype.hasOwnProperty,
+            hasDontEnumBug = !({ toString: null }).propertyIsEnumerable('toString'),
+            dontEnums = [
+                'toString',
+                'toLocaleString',
+                'valueOf',
+                'hasOwnProperty',
+                'isPrototypeOf',
+                'propertyIsEnumerable',
+                'constructor'
+            ],
+            dontEnumsLength = dontEnums.length;
+
+        return function(obj) {
+            if (typeof obj !== 'function' && (typeof obj !== 'object' || obj === null)) {
+                throw new TypeError('Object.keys called on non-object');
+            }
+
+            var result = [], prop, i;
+
+            for (prop in obj) {
+                if (hasOwnProperty.call(obj, prop)) {
+                    result.push(prop);
+                }
+            }
+
+            if (hasDontEnumBug) {
+                for (i = 0; i < dontEnumsLength; i++) {
+                    if (hasOwnProperty.call(obj, dontEnums[i])) {
+                        result.push(dontEnums[i]);
+                    }
+                }
+            }
+            return result;
+        };
+    }());
+}


### PR DESCRIPTION
Adds the `Object.keys` polyfill from MDN as defined here:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys#Polyfill